### PR TITLE
add downloaded image to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+wss-wu-dryville.jpg


### PR DESCRIPTION
Added an image of Dryville to the git repo, but we are ignoring images for the time being, so the image `wss-wu-dryville.jpg` was added to the gitignore file. 

This PR is in reference to issue #16 